### PR TITLE
Removed the need of Activity passing as an argument and fixed buliding issue

### DIFF
--- a/android/src/main/java/bhumi/customInstagramShare/CustomInstagramShareModule.java
+++ b/android/src/main/java/bhumi/customInstagramShare/CustomInstagramShareModule.java
@@ -38,15 +38,13 @@ import java.util.TimerTask;
 import android.content.pm.PackageManager;
 
 public class CustomInstagramShareModule extends ReactContextBaseJavaModule implements ActivityEventListener {
-    private Activity mActivity;
     private ReactApplicationContext reactContext;
     private Callback callback;
 
     final int INSTAGRAM_SHARE_REQUEST = 500;
 
-    public CustomInstagramShareModule(ReactApplicationContext reactContext, Activity activity) {
+    public CustomInstagramShareModule(ReactApplicationContext reactContext) {
         super(reactContext);
-        this.mActivity = activity;
         this.reactContext = reactContext;
         this.reactContext.addActivityEventListener(new RNInstagramShareActivityEventListener());
     }
@@ -92,7 +90,7 @@ public class CustomInstagramShareModule extends ReactContextBaseJavaModule imple
             share.putExtra(Intent.EXTRA_STREAM, uri);
 
             // Broadcast the Intent.
-            mActivity.startActivityForResult(Intent.createChooser(share, "Share to"),INSTAGRAM_SHARE_REQUEST);
+            getCurrentActivity().startActivityForResult(Intent.createChooser(share, "Share to"),INSTAGRAM_SHARE_REQUEST);
           } else{
             callback.invoke("Sorry,file does not exist on given path.");
           }
@@ -110,7 +108,7 @@ public class CustomInstagramShareModule extends ReactContextBaseJavaModule imple
     }
 
     private boolean isAppInstalled(String packageName) {
-        PackageManager pm = mActivity.getPackageManager();
+        PackageManager pm = getCurrentActivity().getPackageManager();
         boolean installed = false;
         try {
            pm.getPackageInfo(packageName, PackageManager.GET_ACTIVITIES);

--- a/android/src/main/java/bhumi/customInstagramShare/CustomInstagramSharePackage.java
+++ b/android/src/main/java/bhumi/customInstagramShare/CustomInstagramSharePackage.java
@@ -1,6 +1,5 @@
 package bhumi.customInstagramShare;
 
-import android.app.Activity;
 
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
@@ -15,20 +14,16 @@ import java.util.List;
 
 public class CustomInstagramSharePackage implements ReactPackage {
 
-    private Activity mActivity = null;
-
-    public CustomInstagramSharePackage(Activity activity) {
-        mActivity = activity;
+    public CustomInstagramSharePackage() {
     }
 
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         return Arrays.<NativeModule>asList(
-                new CustomInstagramShareModule(reactContext, mActivity)
+                new CustomInstagramShareModule(reactContext)
         );
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
There is no need to pass Activity as an argument since you can `getCurrentActivity()` from the ReactContextBaseJavaModule superclass, it is then much easier to use the library since you don't have to make changes to the Application subclass.
Also, removed the `@Overrive` from the  `createJSModules` method since the superclass does not have it in its signature anymore and it was creating a building error.